### PR TITLE
Fix haproxy dataplane (0.0.56-r3)

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-VERSION=0.0.56-r2
+VERSION=0.0.56-r3_test0

--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-VERSION=0.0.56-r3_test5
+VERSION=0.0.56-r3

--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-VERSION=0.0.56-r3_test0
+VERSION=0.0.56-r3_test5

--- a/data-processor-proxy/Dockerfile
+++ b/data-processor-proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM haproxytech/haproxy-debian:2.5.0
+FROM haproxytech/haproxy-debian:2.5.11
 
 COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/data-processor-proxy/Dockerfile
+++ b/data-processor-proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM haproxytech/haproxy-debian:2.5.12
+FROM haproxytech/haproxy-debian:2.5.0
 
 COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -42,7 +42,7 @@ services:
       - data-processor-proxy-net
       - entrypoint-net
     volumes:
-      - data-processor-proxy-data:/usr/local/etc/haproxy
+      - data-processor-proxy-data:/usr/local/etc
 
   db:
     environment:

--- a/entrypoint/Dockerfile
+++ b/entrypoint/Dockerfile
@@ -1,3 +1,3 @@
-FROM haproxy:2.5.12-alpine3.17
+FROM haproxy:2.5.11-alpine3.17
 
 COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
Output from version 2.5.12:
```
[NOTICE]   (1) : New program 'api' (8) forked
[NOTICE]   (1) : New worker (9) forked
[NOTICE]   (1) : Loading success.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x10d9a9b]

goroutine 1 [running]:
github.com/haproxytech/dataplaneapi.SyncWithFileSettings(0xc0001a0000, 0xc000050370?)
        github.com/haproxytech/dataplaneapi/dataplaneapi_configuration.go:38 +0xfb
main.startServer(0xc000424f00)
        github.com/haproxytech/dataplaneapi/cmd/dataplaneapi/main.go:137 +0x7f2
main.main()
        github.com/haproxytech/dataplaneapi/cmd/dataplaneapi/main.go:59 +0x3d
[NOTICE]   (1) : haproxy version is 2.5.12-7367a7c
[NOTICE]   (1) : path to executable is /usr/local/sbin/haproxy
[ALERT]    (1) : Current program 'api' (8) exited with code 2 (Exit)
[ALERT]    (1) : exit-on-failure: killing every processes with SIGTERM
[ALERT]    (1) : Current worker (9) exited with code 143 (Terminated)
[WARNING]  (1) : All workers exited. Exiting... (2)
```

[Related fix](https://github.com/haproxytech/dataplaneapi/commit/83b7655422e1b2b3095a3f4e01da1552d1a4826a)